### PR TITLE
Show a form to enter link if no link given

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,4 +16,14 @@ function takeScreenShot($link){
 $url = isset($_GET['link'])?$_GET['link']:false;
 if($url !== false)
     takeScreenShot($url);
+else
+{
+	printf('<form action="%s" method="get" id="screenshot_url_form">', $_SERVER["PHP_SELF"]);
+	print '<p><label for="link">Website to screenshot</label></p>';
+	print '<p><input type="url" id="link" name="link" placeholder="https:://example.org/"></p>';
+	print '<p><input type="checkbox" id="download" name="download"><label for="download">Download file</label></p>';
+	print '<p><input type="submit" value="Take screenshot"></p>';
+	print '<input type="url" id="link" name="link" placeholder="https:://example.org/">';
+	print '</form>';
+}
 ?>


### PR DESCRIPTION
I was confused about the workings of this script at first, because I didn't know you had to enter the URL into the query string, like ?link=…

Instead of showing a blank page, I suggest showing a simple form to guide the user into using this script.

(This might not merge cleanly with PR #2 , but that can be fixed.)